### PR TITLE
Fix widget not showing ('Incorrect use of ParentDataWidget')

### DIFF
--- a/lib/src/color_picker.dart
+++ b/lib/src/color_picker.dart
@@ -309,13 +309,15 @@ class _ColorPickerState extends State<ColorPicker> {
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                _buildHead(),
-                _buildDropdown(),
-                _buildAlphaPicker(),
-              ],
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  _buildHead(),
+                  _buildDropdown(),
+                  _buildAlphaPicker(),
+                ],
+              ),
             ),
             Expanded(
               child: _buildBody(),


### PR DESCRIPTION
Fixes https://github.com/fluttercandies/flutter_hsvcolor_picker/issues/7