### PR TITLE
CI(security): harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
@@ -22,6 +26,8 @@ updates:
     directory: "example"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
@@ -30,3 +36,5 @@ updates:
     directory: "example/android"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pub_dry_run.yml
+++ b/.github/workflows/pub_dry_run.yml
@@ -8,14 +8,18 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Dry run
-        uses: k-paxian/dart-package-publisher@v1.6
+        uses: k-paxian/dart-package-publisher@532e6f31bf6171f0043d3ff5fa31437afe5249c2
         with:
           credentialJson: 'MockCredentialJson'
           flutter: true

--- a/.github/workflows/pub_publish.yml
+++ b/.github/workflows/pub_publish.yml
@@ -5,14 +5,19 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Publish
-        uses: k-paxian/dart-package-publisher@v1.6
+        uses: k-paxian/dart-package-publisher@532e6f31bf6171f0043d3ff5fa31437afe5249c2
         with:
           credentialJson: ${{ secrets.CREDENTIAL_JSON }}
           flutter: true


### PR DESCRIPTION
Addresses the zizmor findings reported in fluttercandies/security-scanner#19. Only files under `.github/` are changed.

## Changes

### `.github/workflows/pub_dry_run.yml`
- **unpinned-uses (High):** pinned `actions/checkout@v7` → `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` and `k-paxian/dart-package-publisher@v1.6` → `k-paxian/dart-package-publisher@532e6f31bf6171f0043d3ff5fa31437afe5249c2`.
- **artipacked (Low):** added `persist-credentials: false` to the checkout step.
- **excessive-permissions (Medium):** added workflow-level `permissions: {}` (the job is a read-only dry run).

### `.github/workflows/pub_publish.yml`
- **unpinned-uses (High):** pinned both `actions/checkout@v7` and `k-paxian/dart-package-publisher@v1.6` to their commit SHAs (same as above).
- **artipacked (Low):** added `persist-credentials: false` to the checkout step.
- **excessive-permissions (Medium):** added workflow-level `permissions: contents: read`. The job publishes to pub.dev via `secrets.CREDENTIAL_JSON` and needs no GitHub write.

### `.github/dependabot.yml`
- **dependabot-cooldown (Medium ×4):** added `cooldown: default-days: 7` to all four update entries (github-actions, pub, pub example, gradle example/android), each right after its `schedule:` block.

## Validation
All three YAML files parse successfully with `python3 -c "import yaml; yaml.safe_load(...)"`.

Resolves zizmor findings in fluttercandies/security-scanner#19.